### PR TITLE
Fix accidental form submission

### DIFF
--- a/.changeset/hip-beers-listen.md
+++ b/.changeset/hip-beers-listen.md
@@ -1,0 +1,5 @@
+---
+"simple-stack-form": patch
+---
+
+Fix accidental form submission on client validation errors

--- a/examples/form/src/components/preact/Form.tsx
+++ b/examples/form/src/components/preact/Form.tsx
@@ -76,6 +76,7 @@ export function Form({
 						return formContext.trackAstroSubmitStatus();
 					}
 
+					e.preventDefault();
 					e.stopPropagation();
 					formContext.setValidationErrors(parsed.fieldErrors);
 				}}

--- a/examples/form/src/components/react/Form.tsx
+++ b/examples/form/src/components/react/Form.tsx
@@ -78,6 +78,7 @@ export function Form({
 						return formContext.trackAstroSubmitStatus();
 					}
 
+					e.preventDefault();
 					e.stopPropagation();
 					formContext.setValidationErrors(parsed.fieldErrors);
 				}}

--- a/packages/form/templates/preact/Form.tsx
+++ b/packages/form/templates/preact/Form.tsx
@@ -74,6 +74,7 @@ export function Form({
 						return formContext.trackAstroSubmitStatus();
 					}
 
+					e.preventDefault();
 					e.stopPropagation();
 					formContext.setValidationErrors(parsed.fieldErrors);
 				}}

--- a/packages/form/templates/react/Form.tsx
+++ b/packages/form/templates/react/Form.tsx
@@ -78,6 +78,7 @@ export function Form({
 						return formContext.trackAstroSubmitStatus();
 					}
 
+					e.preventDefault();
 					e.stopPropagation();
 					formContext.setValidationErrors(parsed.fieldErrors);
 				}}


### PR DESCRIPTION
Add `preventDefault()` to form submit to prevent submission on client validation errors.