### PR TITLE
`min` and `max` number input props

### DIFF
--- a/.changeset/unlucky-gorillas-learn.md
+++ b/.changeset/unlucky-gorillas-learn.md
@@ -1,0 +1,5 @@
+---
+"simple-stack-form": patch
+---
+
+Add `min` and `max` input props to number input if present on schema

--- a/examples/playground/src/components/react/Signup.tsx
+++ b/examples/playground/src/components/react/Signup.tsx
@@ -14,6 +14,7 @@ export const signup = createForm({
 			return s !== "admin";
 		}),
 	email: z.string().email().optional(),
+	coffees: z.number().lt(10).min(2),
 	optIn: z.boolean().optional(),
 });
 
@@ -34,6 +35,10 @@ export default function Signup({
 			<FormGroup>
 				<label htmlFor={scope("email")}>Email</label>
 				<Input id={scope("email")} {...signup.inputProps.email} />
+			</FormGroup>
+			<FormGroup>
+				<label htmlFor={scope("coffees")}>Coffees taken</label>
+				<Input id={scope("coffees")} {...signup.inputProps.coffees} />
 			</FormGroup>
 			<FormGroup>
 				<label htmlFor={scope("optIn")}>Opt in</label>


### PR DESCRIPTION
## Changes
- Add `min` and `max` params to number input if there are any kind of `min` or `max` validations on the form schema