### PR TITLE
feat: single script insertion strategy

### DIFF
--- a/packages/stream/src/middleware.ts
+++ b/packages/stream/src/middleware.ts
@@ -79,11 +79,8 @@ const SCRIPT_START = `<script>{
 				fallback.replaceWith(fragment);
 			} else if (id-- > 0) {
 				queueMicrotask(replacer);
-			} else {
-				console.error(errormsg);
 			}
 		};
-		let errormsg = "Failed to insert async content (Suspense boundary id: " + id + ")";
 		let fallback;
 	
 		replacer();


### PR DESCRIPTION
This change alters the insertion strategy so that:

1. There is no need for creating and querying a `<template>`.
2. There is only one `<script>` executed.
3. There is no injection of a global variable (`__SIMPLE_SUSPENSE_INSERT`).
4. Uncaught suspense boundaries are moved to the back of the queue, better supporting nested boundaries.