### PR TITLE
adds integration options

### DIFF
--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -3,15 +3,22 @@ import type { AstroIntegration } from "astro";
 const VIRTUAL_MOD_ID = "simple:form";
 const RESOLVED_VIRTUAL_MOD_ID = "\0" + VIRTUAL_MOD_ID;
 
-export default function integration(): AstroIntegration {
+export type Options = {
+	injectMiddleware?: false;
+}
+
+export default function integration(opts?: Options): AstroIntegration {
 	return {
 		name: "simple-form",
 		hooks: {
 			"astro:config:setup"({ addMiddleware, updateConfig }) {
-				addMiddleware({
-					entrypoint: "simple-stack-form/middleware",
-					order: "pre",
-				});
+				const shouldInjectMiddleware = opts?.injectMiddleware ?? 'true'
+				if (shouldInjectMiddleware) {
+					addMiddleware({
+						entrypoint: "simple-stack-form/middleware",
+						order: "pre",
+					});
+				}
 
 				updateConfig({
 					vite: {


### PR DESCRIPTION
## Changes

- Adds the option for users to opt-out of the middleware, if they want to implement the `POST` logic themself, but still use `createForm ` 
- [x] I have read [the "Making a Pull Request" section](https://github.com/bholmesdev/simple-stack/blob/main/CONTRIBUTING.md#making-a-pull-request) before making this PR.

## Testing

existing tests

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Probably we should document the flag, if you agree with it

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
<!-- /cc @withastro/maintainers-docs for feedback! -->

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->