### PR TITLE
refactor: ready -> $.ready

### DIFF
--- a/.changeset/neat-chefs-provide.md
+++ b/.changeset/neat-chefs-provide.md
@@ -1,0 +1,5 @@
+---
+"simple-stack-query": minor
+---
+
+Change from a global `ready()` block from client scripts to a namespaced `$.ready()` block. Should be safer to avoid collisions with any local variables called `ready`.

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -6,7 +6,7 @@ A simple library to query the DOM from your Astro components.
 <button data-target={$('btn')}>Click me</button>
 
 <script>
-  ready(() => {
+  $.ready(() => {
     $('btn').addEventListener('click', () => {
       console.log("It's like JQuery but not!");
     });
@@ -41,15 +41,15 @@ From your client script, the query result will be a plain HTML element. No, it's
 $('btn').addEventListener(() => { /* ... */ });
 ```
 
-You can also pass an `HTMLElement` or `SVGElement` type to access specific properties. For example, use `$<HTMLInputElement>` to access `.value`:
+You can also pass an `HTMLElement` or `SVGElement` type to access specific properties. For example, use `$<HTMLInputElement>()` to access `.value`:
 
 ```ts
 $<HTMLInputElement>('input').value = '';
 ```
 
-### `$.optional` selector
+### `$.optional()` selector
 
-`$` throws when no matching element is found. To avoid this behavior, use `$.optional`:
+`$()` throws when no matching element is found. To avoid this behavior, use `$.optional()`:
 
 ```astro
 ---
@@ -67,9 +67,9 @@ ready(() => {
 </script>
 ```
 
-### `$.all` selector
+### `$.all()` selector
 
-You may want to select multiple targets with the same name. You can use `$.all` to query for an array of results:
+You may want to select multiple targets with the same name. You can use `$.all()` to query for an array of results:
 
 ```astro
 ---
@@ -87,13 +87,13 @@ ready(() => {
 </script>
 ```
 
-## Global `ready()` function
+## Global `$.ready()` function
 
-All `$` queries must be nested in a `ready()` block. This opts in to using the global `$` from client scripts. `ready()` also ensures your code reruns on every page [when view transitions are enabled.](https://docs.astro.build/en/guides/view-transitions/)
+All `$` queries must be nested in a `$.ready()` block. This opts in to using the global `$` from client scripts. `$.ready()` also ensures your code reruns on every page [when view transitions are enabled.](https://docs.astro.build/en/guides/view-transitions/)
 
 ```astro
 <script>
-  ready(() => {
+  $.ready(() => {
     // ✅ Allowed
     $('element').textContent = 'hey';
   })

--- a/packages/query/ambient.d.ts
+++ b/packages/query/ambient.d.ts
@@ -5,6 +5,5 @@ declare namespace $ {
 	function optional<T extends Element = HTMLElement>(
 		selector: string,
 	): T | undefined;
+	function ready(callback: () => void): void;
 }
-
-declare function ready(callback: () => void): void;

--- a/packages/query/fixtures/basic/src/pages/index.astro
+++ b/packages/query/fixtures/basic/src/pages/index.astro
@@ -6,3 +6,9 @@ import WithContext from "./WithContext.astro";
 <h1 data-target={$('test')}>Hey</h1>
 <Nested />
 <WithContext $context={$} />
+
+<script>
+  $.ready(() => {
+    $('test').textContent = 'Hello';
+  });
+</script>

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -42,8 +42,7 @@ function vitePlugin(): VitePlugin {
     import { scope as __scope } from 'simple:scope';
     import * as __queryInternals from "simple-stack-query/internal";
 
-    const $ = __queryInternals.create$(__scope);
-    const ready = __queryInternals.createReady(__scope);\n${code}`;
+    const $ = __queryInternals.create$(__scope);\n${code}`;
 		},
 	};
 }

--- a/www/src/content/docs/query.md
+++ b/www/src/content/docs/query.md
@@ -9,7 +9,7 @@ A simple library to query the DOM from your Astro components.
 <button data-target={$('btn')}>Click me</button>
 
 <script>
-  ready(() => {
+  $.ready(() => {
     $('btn').addEventListener('click', () => {
       console.log("It's like JQuery but not!");
     });
@@ -44,15 +44,15 @@ From your client script, the query result will be a plain HTML element. No, it's
 $('btn').addEventListener(() => { /* ... */ });
 ```
 
-You can also pass an `HTMLElement` or `SVGElement` type to access specific properties. For example, use `$<HTMLInputElement>` to access `.value`:
+You can also pass an `HTMLElement` or `SVGElement` type to access specific properties. For example, use `$<HTMLInputElement>()` to access `.value`:
 
 ```ts
 $<HTMLInputElement>('input').value = '';
 ```
 
-### `$.optional` selector
+### `$.optional()` selector
 
-`$` throws when no matching element is found. To avoid this behavior, use `$.optional`:
+`$()` throws when no matching element is found. To avoid this behavior, use `$.optional()`:
 
 ```astro
 ---
@@ -70,9 +70,9 @@ ready(() => {
 </script>
 ```
 
-### `$.all` selector
+### `$.all()` selector
 
-You may want to select multiple targets with the same name. You can use `$.all` to query for an array of results:
+You may want to select multiple targets with the same name. You can use `$.all()` to query for an array of results:
 
 ```astro
 ---
@@ -90,13 +90,13 @@ ready(() => {
 </script>
 ```
 
-## Global `ready()` function
+## Global `$.ready()` function
 
-All `$` queries must be nested in a `ready()` block. This opts in to using the global `$` from client scripts. `ready()` also ensures your code reruns on every page [when view transitions are enabled.](https://docs.astro.build/en/guides/view-transitions/)
+All `$` queries must be nested in a `$.ready()` block. This opts in to using the global `$` from client scripts. `$.ready()` also ensures your code reruns on every page [when view transitions are enabled.](https://docs.astro.build/en/guides/view-transitions/)
 
 ```astro
 <script>
-  ready(() => {
+  $.ready(() => {
     // ✅ Allowed
     $('element').textContent = 'hey';
   })


### PR DESCRIPTION
## Changes

Move from a global `ready()` block to a `$.ready()` block. It's 10% more ugly, but 100% safer for namespace collisions!

- [X] I have read [the "Making a Pull Request" section](https://github.com/bholmesdev/simple-stack/blob/main/CONTRIBUTING.md#making-a-pull-request) before making this PR.

## Testing

Add client `script` to fixture for manual testing. TODO: e2e test

## Docs

Update `ready()` references in docs.