### PR TITLE
fix: check for fallback when using view transitions event

### DIFF
--- a/.changeset/metal-sloths-occur.md
+++ b/.changeset/metal-sloths-occur.md
@@ -1,0 +1,5 @@
+---
+"simple-stack-query": patch
+---
+
+fixes issue where `$.ready` does not fire in Safari or Firefox when using Astro view transitions with `fallback="none"`

--- a/packages/query/src/internal.ts
+++ b/packages/query/src/internal.ts
@@ -1,8 +1,5 @@
 import type { scope as scopeFn } from "simple:scope";
-import {
-	transitionEnabledOnThisPage,
-	supportsViewTransitions,
-} from "astro/virtual-modules/transitions-router.js";
+import { transitionEnabledOnThisPage } from "astro/virtual-modules/transitions-router.js";
 
 export function create$(scope: typeof scopeFn) {
 	const anyMatchSelector = `[data-target$=${JSON.stringify(scope())}`;

--- a/packages/query/src/internal.ts
+++ b/packages/query/src/internal.ts
@@ -1,5 +1,8 @@
 import type { scope as scopeFn } from "simple:scope";
-import { transitionEnabledOnThisPage } from "astro/virtual-modules/transitions-router.js";
+import {
+	transitionEnabledOnThisPage,
+	supportsViewTransitions,
+} from "astro/virtual-modules/transitions-router.js";
 
 export function create$(scope: typeof scopeFn) {
 	const anyMatchSelector = `[data-target$=${JSON.stringify(scope())}`;
@@ -25,7 +28,7 @@ export function create$(scope: typeof scopeFn) {
 			return [...document.querySelectorAll(selector)];
 		},
 		ready(callback: () => MaybePromise<undefined | (() => void)>) {
-			if (transitionEnabledOnThisPage()) {
+			if (supportsViewTransitions && transitionEnabledOnThisPage()) {
 				let cleanup: (() => void) | undefined;
 
 				document.addEventListener("astro:page-load", async () => {

--- a/packages/query/src/internal.ts
+++ b/packages/query/src/internal.ts
@@ -28,7 +28,10 @@ export function create$(scope: typeof scopeFn) {
 			return [...document.querySelectorAll(selector)];
 		},
 		ready(callback: () => MaybePromise<undefined | (() => void)>) {
-			if (supportsViewTransitions && transitionEnabledOnThisPage()) {
+			const fallback = document
+				.querySelector('meta[name="astro-view-transitions-fallback"]')
+				?.getAttribute("content");
+			if (transitionEnabledOnThisPage() && fallback !== "none") {
 				let cleanup: (() => void) | undefined;
 
 				document.addEventListener("astro:page-load", async () => {


### PR DESCRIPTION
## Changes

Fixes issue where scripts do not run in Safari or Firefox when the view transition fallback is set to `none`.

[Tracking issue on Astro repo](https://github.com/withastro/astro/issues/11528) to set `transitionEnabled` to `false` when the fallback is set to `none`

- [X] I have read [the "Making a Pull Request" section](https://github.com/bholmesdev/simple-stack/blob/main/CONTRIBUTING.md#making-a-pull-request) before making this PR.

## Testing

Manual testing against bholmes.dev

## Docs

N/A