### PR TITLE
feat(www): SEO/AEO improvements — sitemap, robots.txt, structured data, optimized titles

### DIFF
--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -2,6 +2,7 @@ import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
+	site: "https://simple-stack.dev",
 	integrations: [
 		starlight({
 			title: "Simple Stack 🌱",
@@ -12,6 +13,22 @@ export default defineConfig({
 					href: "https://github.com/bholmesdev/simple-stack",
 				},
 				{ icon: "discord", label: "Discord", href: "https://wtw.dev/chat" },
+			],
+			head: [
+				{
+					tag: "script",
+					attrs: { type: "application/ld+json" },
+					content: JSON.stringify({
+						"@context": "https://schema.org",
+						"@type": "Organization",
+						name: "Simple Stack",
+						url: "https://simple-stack.dev",
+						logo: "https://simple-stack.dev/favicon.svg",
+						sameAs: [
+							"https://github.com/bholmesdev/simple-stack",
+						],
+					}),
+				},
 			],
 			sidebar: [
 				{

--- a/www/public/robots.txt
+++ b/www/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://simple-stack.dev/sitemap-index.xml

--- a/www/src/content/docs/index.mdx
+++ b/www/src/content/docs/index.mdx
@@ -1,10 +1,14 @@
 ---
-title: Simple stack 🌱
-description: A suite of tools built for Astro to simplify your workflow.
+title: Simple Stack
+description: Lightweight, focused tools for web development. Includes a reactive state management store for React, build-time scoped IDs for Vite, and DOM querying utilities for Astro.
 tableOfContents: false
 head:
   - tag: title
-    content: Simple stack 🌱
+    content: Simple Stack — Lightweight Tools for Web Development
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: '{"@context":"https://schema.org","@type":"WebSite","name":"Simple Stack","url":"https://simple-stack.dev","description":"Lightweight, focused tools for web development including reactive state management, scoped IDs, and DOM querying utilities."}'
 ---
 
 A collection of tools I've built to **make web development simpler.**

--- a/www/src/content/docs/query.mdx
+++ b/www/src/content/docs/query.mdx
@@ -1,6 +1,13 @@
 ---
-title: 💰 Simple Query
-description: A simple library to query the DOM from your Astro components.
+title: Simple Query — DOM Querying for Astro Components
+description: A simple library to query the DOM from Astro components with scoped selectors, signals support, and server data passing.
+sidebar:
+  label: 💰 Simple Query
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: '{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"@simplestack/query","description":"A simple library to query the DOM from Astro components with scoped selectors and signals.","codeRepository":"https://github.com/bholmesdev/simplestack-query","programmingLanguage":"TypeScript","license":"https://opensource.org/licenses/MIT"}'
 ---
 
 import { Tabs, TabItem, LinkCard } from '@astrojs/starlight/components';

--- a/www/src/content/docs/scope.mdx
+++ b/www/src/content/docs/scope.mdx
@@ -1,6 +1,13 @@
 ---
-title: 🔎 Simple scope
-description: Get a scoped ID for whatever file you're in. Resolved at build-time with zero client JS.
+title: Simple Scope — Build-time Scoped IDs for Vite
+description: Generate scoped IDs for any file at build-time with zero client JS. A Vite plugin compatible with Astro, Nuxt, SvelteKit, and more.
+sidebar:
+  label: 🔎 Simple Scope
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: '{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"vite-plugin-simple-scope","description":"A Vite plugin that generates scoped IDs for any file at build-time with zero client JS.","codeRepository":"https://github.com/bholmesdev/simplestack-scope","programmingLanguage":"TypeScript","license":"https://opensource.org/licenses/MIT"}'
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';

--- a/www/src/content/docs/store.mdx
+++ b/www/src/content/docs/store.mdx
@@ -1,9 +1,14 @@
 ---
-title: 💾 Simple store
-description: A reactive store that combines the simplicity of signals with the power of "selectors" you'd find in Zustand or Redux.
+title: Simple Store — Reactive State Management for React
+description: A reactive store that combines the simplicity of signals with the power of selectors you'd find in Zustand or Redux. Supports sub-stores, middleware, and Next.js SSR.
 sidebar:
-  label: Get started
+  label: 💾 Get started
   order: 1
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: '{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"@simplestack/store","description":"A reactive state management library for React with signal-based stores and selectors.","codeRepository":"https://github.com/bholmesdev/simplestack-store","programmingLanguage":"TypeScript","runtimePlatform":"Node.js","license":"https://opensource.org/licenses/MIT"}'
 ---
 
 import { LinkCard, Tabs, TabItem } from '@astrojs/starlight/components';


### PR DESCRIPTION
## SEO/AEO Audit & Improvements for `www/`

Addresses several SEO and AI visibility issues found during an audit of `simple-stack.dev`.

### What changed

**Critical fixes:**
- Added `site: "https://simple-stack.dev"` to `astro.config.mjs` — enables Starlight's built-in sitemap generation (`/sitemap-index.xml`) and canonical URL support
- Added `robots.txt` to `/public/` with sitemap reference
- These two changes alone fix: missing sitemap (404), missing robots.txt (404), and missing canonical URLs

**Title & meta description improvements:**
- Removed emoji prefixes from page `title` frontmatter (emoji was leaking into `<title>` tags and og:title, e.g. `"💾 Simple store | Simple Stack 🌱"`)
- Emoji moved to `sidebar.label` where it's decorative only and doesn't affect SEO
- Updated titles to be keyword-rich and descriptive (e.g. `"Simple Store — Reactive State Management for React"`)
- Improved meta descriptions with specific feature mentions
- Homepage title changed from generic `"Simple stack 🌱"` to `"Simple Stack — Lightweight Tools for Web Development"`

**Structured data (JSON-LD):**
- Added `Organization` schema site-wide via Starlight's `head` config
- Added `WebSite` schema to the homepage
- Added `SoftwareSourceCode` schema to Store, Scope, and Query pages with repository links and license info

### Before → After (title tags)

| Page | Before | After |
|------|--------|-------|
| Home | `Simple stack 🌱` | `Simple Stack — Lightweight Tools for Web Development` |
| Store | `💾 Simple store \| Simple Stack 🌱` | `Simple Store — Reactive State Management for React \| Simple Stack 🌱` |
| Scope | `🔎 Simple scope \| Simple Stack 🌱` | `Simple Scope — Build-time Scoped IDs for Vite \| Simple Stack 🌱` |
| Query | `💰 Simple Query \| Simple Stack 🌱` | `Simple Query — DOM Querying for Astro Components \| Simple Stack 🌱` |

### Not changed (out of scope or requires external work)
- **`og:image`** — needs a social sharing image to be designed/created
- **Security headers** (X-Content-Type-Options, X-Frame-Options) — configured at the Vercel level, not in source
- **Deprecated pages** (Stream, Form) — left as-is since they're deprecated

_This PR was generated with [Oz](https://www.warp.dev/oz)._
