### PR TITLE
www: SEO/AEO audit fixes (sitemap, robots, JSON-LD, canonicals)

### DIFF
--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -1,10 +1,35 @@
+import sitemap from "@astrojs/sitemap";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
+// Canonical site URL — required for sitemap, canonical links,
+// and the absolute URLs Starlight emits in Open Graph/Twitter meta.
+const SITE_URL = "https://simple-stack.dev";
+
+// Site-wide structured data (Organization) for AEO / AI citations.
+// Helps ChatGPT, Perplexity, Gemini, and Google AI Overviews
+// disambiguate the project as an entity.
+const organizationJsonLd = {
+	"@context": "https://schema.org",
+	"@type": "Organization",
+	name: "Simple Stack",
+	url: SITE_URL,
+	logo: `${SITE_URL}/favicon.svg`,
+	description:
+		"Simple Stack is a suite of small, focused open-source tools for Astro and Vite that simplify common web development workflows.",
+	sameAs: [
+		"https://github.com/bholmesdev/simple-stack",
+		"https://wtw.dev/chat",
+	],
+};
+
 export default defineConfig({
+	site: SITE_URL,
 	integrations: [
 		starlight({
 			title: "Simple Stack 🌱",
+			description:
+				"A suite of small, focused tools for Astro and Vite. Includes Simple Store, Simple Scope, and Simple Query — built to simplify your workflow.",
 			social: [
 				{
 					icon: "github",
@@ -12,6 +37,13 @@ export default defineConfig({
 					href: "https://github.com/bholmesdev/simple-stack",
 				},
 				{ icon: "discord", label: "Discord", href: "https://wtw.dev/chat" },
+			],
+			head: [
+				{
+					tag: "script",
+					attrs: { type: "application/ld+json" },
+					content: JSON.stringify(organizationJsonLd),
+				},
 			],
 			sidebar: [
 				{
@@ -44,5 +76,6 @@ export default defineConfig({
 				"./src/styles/custom.css",
 			],
 		}),
+		sitemap(),
 	],
 });

--- a/www/package.json
+++ b/www/package.json
@@ -17,6 +17,7 @@
 	},
 	"dependencies": {
 		"@astrojs/check": "^0.9.6",
+		"@astrojs/sitemap": "^3.2.1",
 		"@astrojs/starlight": "^0.37.1",
 		"@fontsource/atkinson-hyperlegible": "^5.0.18",
 		"astro": "^5.16.6",

--- a/www/public/robots.txt
+++ b/www/public/robots.txt
@@ -1,0 +1,24 @@
+# https://simple-stack.dev/robots.txt
+User-agent: *
+Allow: /
+
+# AI crawlers — explicitly allowed for AEO / AI citation visibility.
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+Sitemap: https://simple-stack.dev/sitemap-index.xml

--- a/www/src/content/docs/index.mdx
+++ b/www/src/content/docs/index.mdx
@@ -1,10 +1,7 @@
 ---
-title: Simple stack 🌱
-description: A suite of tools built for Astro to simplify your workflow.
+title: Simple Stack — small, focused tools for Astro
+description: Simple Stack is a suite of small, focused open-source tools for Astro and Vite. Includes Simple Store, Simple Scope, and Simple Query — built to simplify common web development workflows.
 tableOfContents: false
-head:
-  - tag: title
-    content: Simple stack 🌱
 ---
 
 A collection of tools I've built to **make web development simpler.**


### PR DESCRIPTION
## SEO/AEO audit of `simple-stack/www`

This PR is the result of an SEO + AEO audit of the Starlight docs site at
[simple-stack.dev](https://simple-stack.dev). It addresses the highest-impact
findings while staying minimal and self-contained.

### Findings (highlights)

**Critical**
- No `site` configured in `astro.config.mjs`. Without it, Astro/Starlight
  cannot emit absolute canonical URLs, the canonical/`og:url`/`twitter:url`
  tags fall back to relative paths, and `@astrojs/sitemap` cannot run.
- No XML sitemap. Search engines have to discover every page by crawling.
- No `robots.txt`. AI crawlers (GPTBot, OAI-SearchBot, PerplexityBot,
  Google-Extended, ClaudeBot, etc.) had no explicit signal and no sitemap
  pointer.

**High**
- No structured data anywhere on the site. AEO benchmarks consistently
  show Organization + FAQPage JSON-LD as the highest-leverage schema for
  AI citations.
- Homepage frontmatter overrode `<title>` to `Simple stack 🌱` (an
  emoji-only title), which suppressed Starlight's brand template and
  produced a SERP entry with weak keywords.
- Homepage `description` was generic ("A suite of tools built for Astro
  to simplify your workflow.") and missing the product names that drive
  branded queries.

**Medium / Ongoing** (not in this PR — see below)
- Stream and Form sections are deprecated but currently indexable. They
  should likely be `noindex` and excluded from the sitemap so AI/search
  don't surface unmaintained content.
- No FAQPage JSON-LD on landing pages. Low-effort and high-impact for
  ChatGPT/Perplexity/Google AI Overviews citations.
- No Open Graph image. Starlight inherits the favicon — fine but not branded.
- Two large media assets (`astro-partial-rendering-demo.mp4` ~14MB,
  `simple-stream-intro.mov` ~3.4MB) ship from `public/assets/` on every
  deploy. Host externally or `<video preload="none">` with a poster.
- No Lighthouse/PageSpeed step in CI.

### Changes in this PR

1. **`site` URL configured** — `https://simple-stack.dev` added to
   `astro.config.mjs`. Enables absolute canonical/OG/Twitter URLs.
2. **Sitemap** — Added `@astrojs/sitemap` integration. Emits
   `sitemap-index.xml` plus `sitemap-0.xml` on build.
3. **`robots.txt`** — New `www/public/robots.txt` referencing the sitemap
   and explicitly allowing major AI crawlers (AEO).
4. **Organization JSON-LD** — Injected site-wide via Starlight's `head`
   config so AI engines and Google can disambiguate the project as an
   entity (`name`, `url`, `logo`, `description`, `sameAs`).
5. **Default site description** — Added a top-level `description` so
   pages without frontmatter `description` inherit a meaningful default.
6. **Homepage metadata** — Removed the redundant `head: title` override,
   replaced the emoji-only title with a descriptive one, and expanded the
   description to include the product names that drive branded search.

### Note on the existing `oz/seo-aeo-audit-www` branch

A previous remote branch with a similar name already exists (Ben's
commit `2b5ee58`) and goes further: it also adds FAQPage JSON-LD to the
home page, marks deprecated docs `noindex`, and excludes them from the
sitemap. Consider merging the two — that branch is a good template for
the "Suggested follow-ups" section above.

### Suggested follow-ups (not in this PR)

- `noindex` deprecated `stream.md` and `form/*.md{x}` and exclude them
  from the sitemap with `sitemap({ filter: ... })`.
- Add `FAQPage` JSON-LD to home + `store.mdx` / `query.mdx` / `scope.mdx`
  covering "What is …", "How do I install …", "Is it production-ready?".
- Add a branded `og:image` and reference it from Starlight `head`.
- Move large demo `.mp4`/`.mov` files out of `public/` or lazy-load.

### Validation

`pnpm install` was attempted in the sandbox to run `astro build`, but the
sandbox network timed out before it completed. The changes are
configuration-only and follow the documented Starlight + `@astrojs/sitemap`
patterns; please run `pnpm install && pnpm --filter docs build` locally
to verify.

_Conversation: https://app.warp.dev/conversation/0b12e656-aa9e-4a08-ae5b-2ba337858621_
_Run: https://oz.warp.dev/runs/019ddd9d-dd42-7c07-9e12-82d2e0bb3366_

_This PR was generated with [Oz](https://warp.dev/oz)._
